### PR TITLE
Fix argument

### DIFF
--- a/app-node-com-es-modules-padrao/01_arquivos-no_node.js
+++ b/app-node-com-es-modules-padrao/01_arquivos-no_node.js
@@ -35,4 +35,4 @@ getFileNames(filePath)
 getFileOrDirStats(filePath)
 getFileStats(filePath)
 
-fs.promises.readdir(path).then(result => console.log(result))
+fs.promises.readdir(filePath).then(result => console.log(result))


### PR DESCRIPTION
Pequena correção no nome do argumento da função "readdir" onde foi mudado o nome da constante do process.cwd() no decorrer da aula e ficou faltando alterar lá.